### PR TITLE
Many to many support

### DIFF
--- a/src/SimpleThings/EntityAudit/EventListener/CreateSchemaListener.php
+++ b/src/SimpleThings/EntityAudit/EventListener/CreateSchemaListener.php
@@ -98,7 +98,37 @@ class CreateSchemaListener implements EventSubscriber
         $pkColumns[] = $this->config->getRevisionFieldName();
         $revisionTable->setPrimaryKey($pkColumns);
         $revIndexName = $this->config->getRevisionFieldName().'_'.md5($revisionTable->getName()).'_idx';
-        $revisionTable->addIndex(array($this->config->getRevisionFieldName()),$revIndexName);
+        $revisionTable->addIndex(array($this->config->getRevisionFieldName()), $revIndexName);
+
+        foreach ($cm->associationMappings AS $associationMapping) {
+            if ($associationMapping['isOwningSide'] && isset($associationMapping['joinTable'])) {
+                if (isset($associationMapping['joinTable']['name'])) {
+                    $joinTable = $schema->getTable($associationMapping['joinTable']['name']);
+                    $revisionJoinTable = $schema->createTable(
+                        $this->config->getTablePrefix().$joinTable->getName().$this->config->getTableSuffix()
+                    );
+                    foreach ($joinTable->getColumns() AS $column) {
+                        /* @var Column $column */
+                        $revisionJoinTable->addColumn(
+                            $column->getName(),
+                            $column->getType()->getName(),
+                            array_merge(
+                                $column->toArray(),
+                                array('notnull' => false, 'autoincrement' => false)
+                            )
+                        );
+                    }
+                    $revisionJoinTable->addColumn($this->config->getRevisionFieldName(), $this->config->getRevisionIdFieldType());
+                    $revisionJoinTable->addColumn($this->config->getRevisionTypeFieldName(), 'string', array('length' => 4));
+
+                    $pkColumns = $joinTable->getPrimaryKey()->getColumns();
+                    $pkColumns[] = $this->config->getRevisionFieldName();
+                    $revisionJoinTable->setPrimaryKey($pkColumns);
+                    $revIndexName = $this->config->getRevisionFieldName().'_'.md5($revisionJoinTable->getName()).'_idx';
+                    $revisionJoinTable->addIndex(array($this->config->getRevisionFieldName()), $revIndexName);
+                }
+            }
+        }
     }
 
     public function postGenerateSchema(GenerateSchemaEventArgs $eventArgs)


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Has tests?    | no
| Fixed tickets | #295, #161, #85

Currently EntityAuditBundle allows to audit entites which have many to many relations but not stores versioned data of relation. Changes in this PR adds versioned many to many relation support.
